### PR TITLE
🧹 Remove duplicate 'PN' document type

### DIFF
--- a/hl7.yml
+++ b/hl7.yml
@@ -65,7 +65,6 @@ document:
   - "PC"
   - "PH"
   - "PN"
-  - "PN"
   - "SP"
   - "TS"
 


### PR DESCRIPTION
🎯 **What:** Removed a duplicate entry "PN" from the `document.types` list in `hl7.yml`.
💡 **Why:** This improves maintainability and readability by eliminating redundant configuration entries.
✅ **Verification:**
- Verified the YAML syntax using Ruby's YAML module.
- Confirmed with `grep` that only one "PN" entry remains.
- Performed a syntax check on all YAML files in the repository.
✨ **Result:** A cleaner and more maintainable configuration file.

---
*PR created automatically by Jules for task [11103984175218238003](https://jules.google.com/task/11103984175218238003) started by @benbarnard-OMI*