### PR TITLE
🔒 Fix hardcoded Primary Facility ID in hl7.yml

### DIFF
--- a/hl7.yml
+++ b/hl7.yml
@@ -159,7 +159,7 @@ abnormal_flags:
 
 primary_facility:
   organization_name: "FAMILY PRACTICE"
-  id_number: "12345"
+  id_number: "${PRIMARY_FACILITY_ID}"
 
 #
 # Hospital Service (PV1.10 - Hospital Service).


### PR DESCRIPTION
🎯 **What:** The `id_number` field under `primary_facility` in `hl7.yml` was hardcoded to "12345". This has been replaced with the parameter `${PRIMARY_FACILITY_ID}`.
⚠️ **Risk:** Hardcoding a facility ID, particularly if it relates to real-world identifiers or API integrations, presents a security risk. If a real ID were checked in, an attacker might be able to exploit it (e.g., impersonate the facility) or it could cause test data to leak into production environments if not properly isolated. It also limits the configuration's flexibility across environments (dev, staging, prod).
🛡️ **Solution:** Substituted the static string with an environment variable placeholder. This ensures the repository remains clean of sensitive organizational data, relying instead on the environment or deployment system to inject the appropriate, secure ID at runtime.

---
*PR created automatically by Jules for task [95724557180706141](https://jules.google.com/task/95724557180706141) started by @benbarnard-OMI*