### PR TITLE
🧹 Remove duplicate Document Type in hl7.yml

### DIFF
--- a/hl7.yml
+++ b/hl7.yml
@@ -65,7 +65,6 @@ document:
   - "PC"
   - "PH"
   - "PN"
-  - "PN"
   - "SP"
   - "TS"
 


### PR DESCRIPTION
🎯 **What:** Removed the duplicate `"PN"` entry in the `document.types` list within `hl7.yml`.
💡 **Why:** Improving maintainability and readability by eliminating redundant configuration entries.
✅ **Verification:** Confirmed removal via manual inspection and verified using a Ruby script to ensure no duplicates remain in the YAML file.
✨ **Result:** A cleaner and more accurate HL7 configuration.

---
*PR created automatically by Jules for task [4173337900638668396](https://jules.google.com/task/4173337900638668396) started by @benbarnard-OMI*