### PR TITLE
🔒 Fix duplicate configuration entry in hl7.yml

### DIFF
--- a/hl7.yml
+++ b/hl7.yml
@@ -65,7 +65,6 @@ document:
   - "PC"
   - "PH"
   - "PN"
-  - "PN"
   - "SP"
   - "TS"
 


### PR DESCRIPTION
🎯 **What:** Removed duplicate `PN` string in the document types list of `hl7.yml`.
⚠️ **Risk:** Duplicate configuration items can introduce logic bugs if parsing logic expects uniqueness or fails. Though it's low risk here, keeping duplicate data is poor code hygiene and could lead to unforeseen issues down the line.
🛡️ **Solution:** Removed the duplicate `- "PN"` entry at line 68 in `hl7.yml` leaving only one `PN` document type element.

---
*PR created automatically by Jules for task [2859694299587578450](https://jules.google.com/task/2859694299587578450) started by @benbarnard-OMI*