### PR TITLE
🔒 Fix hardcoded facility ID in hl7.yml

### DIFF
--- a/hl7.yml
+++ b/hl7.yml
@@ -158,8 +158,8 @@ abnormal_flags:
   above_high_normal: "H"
 
 primary_facility:
-  organization_name: "FAMILY PRACTICE"
-  id_number: "12345"
+  organization_name: "${ORGANIZATION_NAME}"
+  id_number: "${ORGANIZATION_ID}"
 
 #
 # Hospital Service (PV1.10 - Hospital Service).


### PR DESCRIPTION
🎯 **What:** The `id_number` and `organization_name` in `hl7.yml` for the `primary_facility` were hardcoded values.
⚠️ **Risk:** Hardcoding configuration details such as facility ID can expose sensitive or organizational specific data, potentially putting the codebase and its users at risk if exploited.
🛡️ **Solution:** Replaced the hardcoded values with standard bash-style environment variables (`${ORGANIZATION_NAME}` and `${ORGANIZATION_ID}`) so these identifiers can be injected securely at runtime rather than being committed directly in the configuration file.

---
*PR created automatically by Jules for task [13571014740198074372](https://jules.google.com/task/13571014740198074372) started by @benbarnard-OMI*