### PR TITLE
🧹 Remove duplicate 'PN' document type

### DIFF
--- a/hl7.yml
+++ b/hl7.yml
@@ -65,7 +65,6 @@ document:
   - "PC"
   - "PH"
   - "PN"
-  - "PN"
   - "SP"
   - "TS"
 


### PR DESCRIPTION
🎯 **What:** Removed duplicate 'PN' entry from `document.types` list in `hl7.yml`.
💡 **Why:** Having duplicate entries in a YAML list is redundant and can cause confusion. Removing the duplicate makes the configuration cleaner and easier to maintain.
✅ **Verification:** Verified YAML syntax using Ruby parser (`ruby -e "require 'yaml'; YAML.load_file('hl7.yml')"`) and confirmed no other duplicate entries exist using a custom duplicate-checking script.
✨ **Result:** A cleaner, duplicate-free configuration file that accurately reflects the intended document types without redundancy.

---
*PR created automatically by Jules for task [9422368824201491165](https://jules.google.com/task/9422368824201491165) started by @benbarnard-OMI*