### PR TITLE
🧹 Fix inconsistent list indentation in hl7.yml

### DIFF
--- a/hl7.yml
+++ b/hl7.yml
@@ -54,19 +54,19 @@ document:
   # Reference:
   # https://hl7-definition.caristix.com/v2/HL7v2.3.1/Tables/0270
   types:
-  - "AR"
-  - "CD"
-  - "CN"
-  - "DI"
-  - "DS"
-  - "ED"
-  - "HP"
-  - "OP"
-  - "PC"
-  - "PH"
-  - "PN"
-  - "SP"
-  - "TS"
+    - "AR"
+    - "CD"
+    - "CN"
+    - "DI"
+    - "DS"
+    - "ED"
+    - "HP"
+    - "OP"
+    - "PC"
+    - "PH"
+    - "PN"
+    - "SP"
+    - "TS"
 
 #
 # Procedures.


### PR DESCRIPTION
🎯 **What:** Corrected the list indentation under the 'document' section in `hl7.yml` to be 2 spaces relative to the key (4 spaces absolute).
💡 **Why:** This makes the list formatting consistent with other similar lists in the file (e.g., under 'allergy', 'diagnosis', 'procedure'), improving overall maintainability and code readability.
✅ **Verification:** Ran `ruby -e "require 'yaml'; YAML.load_file('hl7.yml')"` to confirm that the changes did not break YAML validity and preserved the correct parsing of the file structure.
✨ **Result:** A consistent configuration file adhering to the established spacing convention.

---
*PR created automatically by Jules for task [367741835143794977](https://jules.google.com/task/367741835143794977) started by @benbarnard-OMI*