### PR TITLE
🧹 Remove empty building key from locations.yml

### DIFF
--- a/locations.yml
+++ b/locations.yml
@@ -15,7 +15,6 @@
 ED:
   poc: ED
   facility: "${ORGANIZATION_NAME}"
-  building:
   floor: 1
   room: ED
   type: ED


### PR DESCRIPTION
🎯 **What:** Removed the empty `building:` key from the `ED` location block in `locations.yml`.
💡 **Why:** Empty YAML keys don't add semantic value and clutter the configuration file, reducing maintainability and readability. Removing it prevents confusion about whether a building should be specified.
✅ **Verification:** Validated that the updated `locations.yml` file is syntactically valid YAML using Ruby's YAML parser. The code review also confirmed the change is safe and trivial.
✨ **Result:** A slightly cleaner and more maintainable configuration file without altering any functionality.

---
*PR created automatically by Jules for task [13792538368622848955](https://jules.google.com/task/13792538368622848955) started by @benbarnard-OMI*