### PR TITLE
🧹 [code health] Remove duplicated 'Ph.D.' in data.yml

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -85,7 +85,6 @@ patient_name:
     - "Jnr"
     - "II"
     - "III"
-    - "Ph.D."
     - "B.Sc"
     - "M.A."
     - "CCNA"


### PR DESCRIPTION
🎯 **What:** Removed duplicate "Ph.D." entry under patient `suffixes` in `data.yml`.
💡 **Why:** Having duplicate entries in configuration files can cause confusion and unnecessary bloat, so removing it improves maintainability.
✅ **Verification:** Ran a Ruby script to verify YAML syntax and confirm the removal of the duplicate item. Checked that it was correctly removed from `suffixes` but remained in `degrees`. No tests exist or were required for this config-only repository.
✨ **Result:** A cleaner `data.yml` configuration without redundant values.

---
*PR created automatically by Jules for task [4650787499440516292](https://jules.google.com/task/4650787499440516292) started by @benbarnard-OMI*