### PR TITLE
🔒 Fix insecure HTTP URLs across configuration files

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -108,7 +108,7 @@ patient_name:
   male_prefixes:
     - "Mr"
   # In 1911 only 37% babies were given middle name, these days - 80%:
-  # http://www.dailymail.co.uk/news/article-2515376/Middle-names-booming-80-children-given-parents-chosen-honour-lost-relatives.html
+  # https://www.dailymail.co.uk/news/article-2515376/Middle-names-booming-80-children-given-parents-chosen-honour-lost-relatives.html
   # Assume an average of 55%.
   middlename_percentage: 55
 

--- a/doctors.yml
+++ b/doctors.yml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Specialties come from
-# http://hl7-definition.caristix.com:9010/Default.aspx?version=HL7%20v2.5.1&table=0069
+# https://hl7-definition.caristix.com/v2/HL7v2.5.1/Tables/0069
 - id: "C001"
   surname: "Forster"
   firstname: "Richard"

--- a/locations.yml
+++ b/locations.yml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
🎯 **What:** 
Updated insecure `http://` URLs to secure `https://` URLs in `doctors.yml`, `data.yml`, and `locations.yml`. This includes migrating the legacy Caristix port 9010 URL to the modern HTTPS structure (`https://hl7-definition.caristix.com/v2/HL7v2.5.1/Tables/0069`), updating the Daily Mail reference link, and updating Apache license headers.

⚠️ **Risk:** 
Using `http://` for external links can expose users to man-in-the-middle attacks, potentially leading to interception or manipulation of the data they receive when accessing those links. While these are primarily reference links in comments, maintaining secure defaults is a fundamental security best practice.

🛡️ **Solution:** 
Replaced `http://` with `https://` for all applicable URLs across the configuration files. The YAML syntax was validated using Ruby's built-in YAML parser to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [9793930673285944781](https://jules.google.com/task/9793930673285944781) started by @benbarnard-OMI*